### PR TITLE
Fix typos and remove some trailing whitespaces

### DIFF
--- a/R/plotRules.R
+++ b/R/plotRules.R
@@ -18,7 +18,7 @@ function(rules, zcolor = "bw", ellipse = FALSE, opacity = 0.3,
 
     # create dummy global variables x and y to comply with R CMD check
     # when they are used for aes(x, y) in ggplots
-    x <- NULL 
+    x <- NULL
     y <- NULL
 
 
@@ -214,7 +214,7 @@ function(rules, zcolor = "bw", ellipse = FALSE, opacity = 0.3,
 
             if (length(other.args) > 0) {
 
-                # there might be different border colors for each zone (set in this case) 
+                # there might be different border colors for each zone (set in this case)
                 # arguments are recycled to the length of the zones
                 other.args <- lapply(other.args, function(x) {
                     rep(x, length.out = nofsets)

--- a/R/plotRules.R
+++ b/R/plotRules.R
@@ -63,7 +63,7 @@ function(rules, zcolor = "bw", ellipse = FALSE, opacity = 0.3,
         })
 
 
-        # check if any of the remaining rowns define a whole set
+        # check if any of the remaining rows define a whole set
 
         # wholesets will be a numeric vector:
         # 0 if it's not a whole set
@@ -105,7 +105,7 @@ function(rules, zcolor = "bw", ellipse = FALSE, opacity = 0.3,
         if (any(!irregular)) { # normal shapes
             if (any(wholesets > 0)) {
                 for (i in which(wholesets > 0)) {
-                    # [[1]] simulates getZones() because sometimes there might be multipe zones
+                    # [[1]] simulates getZones() because sometimes there might be multiple zones
                     zones[[i]][[1]] <- sets[sets$s == nofsets & sets$v == as.numeric(ellipse) & sets$n == wholesets[i], c("x", "y")]
                 }
             }

--- a/R/venn.R
+++ b/R/venn.R
@@ -325,7 +325,7 @@ function(x, snames = "", ilabels = NULL, ellipse = FALSE, zcolor = "bw",
                     }
                 }
             }
-        }        
+        }
 
         if (isTRUE(counts) & is.null(cts)) {
             cts <- tt$n
@@ -652,17 +652,17 @@ function(x, snames = "", ilabels = NULL, ellipse = FALSE, zcolor = "bw",
                 xmin = 10, xmax = 32, ymin = -44, ymax = -22,
                 fill = ttcolors[1],
                 col = "black"
-            ) + 
+            ) +
             ggplot2::annotate("rect",
                 xmin = 120, xmax = 142, ymin = -44, ymax = -22,
                 fill = ttcolors[2],
                 col = "black"
-            ) + 
+            ) +
             ggplot2::annotate("rect",
                 xmin = 230, xmax = 252, ymin = -44, ymax = -22,
                 fill = ttcolors[3],
                 col = "black"
-            ) + 
+            ) +
             ggplot2::annotate("rect",
                 xmin = 340, xmax = 362, ymin = -44, ymax = -22,
                 fill = ttcolors[4],

--- a/man/getZones.Rd
+++ b/man/getZones.Rd
@@ -14,7 +14,7 @@ getZones(area, snames, ellipse = FALSE)
 }
 
 \arguments{
-  \item{area}{A chgaracter expression written in sum of products form.}
+  \item{area}{A character expression written in sum of products form.}
   \item{snames}{A string containing the sets' names, separated by commas.}
   \item{ellipse}{Logical, get the zones from the shape of an ellipse, where possible}
 }

--- a/man/venn.Rd
+++ b/man/venn.Rd
@@ -88,7 +88,7 @@ A numerical vector can be supplied with the argument \bold{\code{ilabels}}, when
 the argument \bold{\code{x}} is a single number of sets. The vector should match
 the increasing order of the binary representation for the set intersections.
 
-This argumet can also be logical, and if activated with \code{TRUE} it constructs
+This argument can also be logical, and if activated with \code{TRUE} it constructs
 the intersection labels from their particular combinations of 0s and 1s.
 
 Finally, it can also be specified as \code{ilabels = "counts"}, for counting the
@@ -133,7 +133,7 @@ automatically decreases to 0.5 for six sets and 0.45 for seven sets.
 Via \bold{\code{...}}, users can specify additional parameters, mainly for the
 outer borders of the sets, as specified by \bold{\code{\link[graphics]{par}()}},
 and since version 1.9 it is also used to pass additional aesthetics parameters
-for the ggplot2 graphics. All of them are feeded either to the base function
+for the ggplot2 graphics. All of them are fed either to the base function
 \bold{\code{\link[graphics]{lines}()}} which is responsible with the borders, or
 to the function \bold{\code{\link[ggplot2]{geom_path}()}} from package
 \pkg{ggplot2}.
@@ -144,7 +144,7 @@ sets the shapes cannot be continous (they might be monotone, but not continous).
 The 7 sets diagram is called "Adelaide" (Ruskey, 2005).
 
 The most challenging diagram is the one with 6 sets, where for many years it was
-thought a Venn diagram didn't even exist. All diagrams are symetric, except for
+thought a Venn diagram didn't even exist. All diagrams are symmetric, except for
 the one with 6 sets, where some of the sets have different shapes. The diagram
 in this package is an adaptation from Mamakani, K., Myrvold W. and F. Ruskey (2011).
 

--- a/man/venn.Rd
+++ b/man/venn.Rd
@@ -26,7 +26,7 @@ venn(x, snames = "", ilabels = NULL, ellipse = FALSE, zcolor = "bw",
   \item{opacity}{Degree of opacity for the color(s) specified with
         \code{zcolor} (less opacity, more transparency).}
   \item{plotsize}{Plot size, in centimeters.}
-  \item{ilcs}{Character expansion (in base plots) or size (in ggplots) 
+  \item{ilcs}{Character expansion (in base plots) or size (in ggplots)
         for the intersection labels}
   \item{sncs}{Character expansion (in base plots) or size (in ggplots)
         for the set names}
@@ -38,14 +38,14 @@ venn(x, snames = "", ilabels = NULL, ellipse = FALSE, zcolor = "bw",
 }
 
 \details{
-    
+
 The argument \bold{\code{x}} can be either:\cr
 - a single number (of sets), between 1 and 7\cr
 - a metacommand (character) to draw custom intersection zones\cr
 - a list, containing values for the different sets: each component is a set,
   and only up to 7 components are processed.\cr
 - a dataset of boolean values.\cr
-         
+
 A "zone" is a union of set intersections. There are exactly \bold{\code{2^k}}
 intersections in a Venn diagram, where \bold{\code{k}} is the number of sets. To
 highlight an entire set, we need a union of all possible intersections which


### PR DESCRIPTION
I fixed some typos and removed trailing whitespaces except those that match the following criteria:
- those spellings that are valid in British on American English. If valid in at least one of them, I didn't change the existing version
- if the whitespace matches `^\s+$`, and is outside of a `.Rd` section

if you want me to adjust all the indentations and spacing, I will be happy to add another commit to this PR for those too.