### PR TITLE
Fix the line offset for the title if the `line` is not defined by user

### DIFF
--- a/R/openPlot.R
+++ b/R/openPlot.R
@@ -68,7 +68,7 @@
         plot(x = 0:1000, type = "n", axes = FALSE, asp = 1, xlab = "", ylab = "")
 
         if (!is.null(dots$main)) {
-            title(main = dots$main, line = ifelse(is.null(dots$line), -2, dots$line))
+            title(main = dots$main, line = ifelse(is.null(dots$line), -1, dots$line))
         }
     }
 }

--- a/R/openPlot.R
+++ b/R/openPlot.R
@@ -68,7 +68,7 @@
         plot(x = 0:1000, type = "n", axes = FALSE, asp = 1, xlab = "", ylab = "")
 
         if (!is.null(dots$main)) {
-            title(main = dots$main, line = dots$line)
+            title(main = dots$main, line = ifelse(is.null(dots$line), -2, dots$line))
         }
     }
 }


### PR DESCRIPTION
In the current version, if the user defines `main` argument (which is passed to `title()` but does not define the `line` argument, the title will be printed at the edge of the plot. In this PR we check the value, and if the user have not defined the `line`, we default to `-1` to cleanly show at least one line of title.

```r
venn(list(a = letters[1:4],
          b = letters[3:8]),
     main = "test")
```

![image](https://github.com/dusadrian/venn/assets/390889/dc921d12-5ae1-4673-8dd5-439b76cbe122)

To justify value `-1`, here is some different offsets overlaid:

```r
venn(list(a = letters[1:4],
          b = letters[3:8]),
     main = "on line -1",
     line = -1)

title(main = "on line -2", line = -2, col.main = "red")
title(main = "on line 0", line = 0, col.main = "red")
```

![image](https://github.com/dusadrian/venn/assets/390889/919a3939-85a5-4da8-b6f7-e5ec1e76ffb4)
